### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sonic-com/sonic-netbox-zabbix/security/code-scanning/1](https://github.com/sonic-com/sonic-netbox-zabbix/security/code-scanning/1)

To fix this, add an explicit `permissions` block in `.github/workflows/ruff.yml` so the workflow does not inherit potentially broad defaults.  
Best single fix without changing functionality: set workflow-level permissions to read-only for repository contents.

- **File:** `.github/workflows/ruff.yml`
- **Change location:** after the `on:` trigger block (before `jobs:`)
- **Add:**
  - `permissions:`
  - `  contents: read`

This keeps current behavior (checkout + Ruff checks) while explicitly enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
