### PR TITLE
feat: push Netbox cluster name and virt type detail to Zabbix

### DIFF
--- a/netbox_zabbix/sync.py
+++ b/netbox_zabbix/sync.py
@@ -122,6 +122,15 @@ class SonicNetboxZabbix:
                         }
                     )
 
+                if srv.cluster and srv.cluster["name"]:
+                    macros.append(
+                        {
+                            "macro": "{$NETBOX.CLUSTER.NAME}",
+                            "value": srv.cluster["name"],
+                            "description": "Netbox cluster this host belongs to",
+                        }
+                    )
+
                 macros.append(
                     {
                         "macro": "{$NETBOX.DATE.CREATED}",
@@ -210,6 +219,9 @@ class SonicNetboxZabbix:
                             "value": self.netbox.virt_type(srv),
                         }
                     )
+
+                if srv.cluster and srv.cluster["name"]:
+                    tags.append({"tag": "netbox-cluster-name", "value": srv.cluster["name"]})
 
                 if self.netbox.is_physical(srv) and srv.device_type and srv.device_type["slug"]:
                     tags.append({"tag": "netbox-device-type", "value": srv.device_type["slug"]})
@@ -366,6 +378,7 @@ class SonicNetboxZabbix:
                 if self.netbox.is_virtual(srv):
                     inventory["hardware"] = "Virtual"
                     if self.netbox.virt_type(srv):
+                        inventory["hardware"] = f"Virtual ({self.netbox.virt_type(srv)})"
                         inventory["vendor"] = self.netbox.virt_type(srv)
 
                 if self.netbox.is_physical(srv):


### PR DESCRIPTION
- VM inventory "hardware" now reads "Virtual (Proxmox)" / "Virtual (VMware)" instead of plain "Virtual" (falls back to "Virtual" when no cluster type)
- New macro {$NETBOX.CLUSTER.NAME} and tag netbox-cluster-name with the Netbox cluster name (e.g. SR2) on VMs and hypervisor cluster members, to enable alerting on Netbox-vs-platform cluster mismatches